### PR TITLE
rework Dockerfile and documentation to run recommend running this as a service container.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 APP_DIR=./
-USERNAME=joe
-PASSWORD=secret
+# When running as a service container because,
+# access is private to the docker container's internal network
+#USERNAME=joe
+#PASSWORD=secret

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,17 @@ COPY *.go ./
 
 RUN go build -o /cache-http
 
-EXPOSE 3000
+# Because this is designed to run on a private Docker network
+# this will not conflict with anything running on port 80 on the host
+EXPOSE 80
 
-CMD [ "/cache-http", "3000" ]
+# Listen to requests for all IP addresses so that the container
+# can respond both the private name that Github Actions may assign
+# as a service container, while also responding to "localhost" requests
+# if you map the port to be accessible directly from the host.
+#
+# If you want to expose this service to the host and not the whole
+# internet, make sure you Docker port numbers restrict to localhost:
+#  -p 127.0.0.1:3000:80
+
+CMD [ "/cache-http", "--host=", "--port=80" ]

--- a/README.md
+++ b/README.md
@@ -1,17 +1,32 @@
-#### About
+## About
 
 Alternate solution to action/cache for GHES and self-hosted runners on Docker.
+[Github's "action/cache" plugin current doesn't support GHES and self-hosted runners.]
+(https://github.com/actions/cache/issues/505)
 
-https://github.com/actions/cache/issues/505
+## Github Enterprise / self-hosted runner workflow
 
-#### Run
-```
-go run main.go 3000
-```
+The syntax is varies depending on whether your app that needs the cache is running 
+in a Docker container or directly on the host.
 
-#### GHE workflow
+Both cases the companion ["action-cache-http"](https://github.com/marketplace/actions/action-cache-http) Action.
 
-https://github.com/marketplace/actions/action-cache-http
+When your app is built in a docker container, Github Actions will automatically will assign
+the host name "cache-http" to this service container, so the configuration will
+access by that host on port 80.
+
+When your app is built directly on the host, you'll need to map port 80 inside the cache-http
+container to a free port on your host. In the example below, we use port 3000.
+
+In both cases we use a bind mount to allow the service container to persist the assets on the host.
+
+Currently, there is no automated cache pruning but see [clear\_retention.sh(./clear\_retention.sh)
+for an example that you could run on a cron job or system timer.
+
+Note: There's no authentication on the default Docker image. It's assumed that access to
+the service will be restricted to Dockerized builts or only to "localhost" requests from
+your CI server.
+
 
 ```yml
 on: [push]
@@ -23,6 +38,23 @@ jobs:
       matrix:
         node-versions: ['10.16.3', '14.9']
     runs-on: self-hosted
+  # Cache service for GHE / self-hosted runners
+    services:
+      cache-http:
+        image: docker.pkg.github.com/SOMEPATH/FIXME/cache-http:3
+        # For now you still need to authenticate when accessing public packages
+        credentials:
+          username: $GITHUB_ACTOR
+          password: ${{ secrets.SOME_SECRET }}
+       # The left side is any path on your host you want to store the cache
+       # Make sure the directory exists. Right side must be "/app/assets!"
+        volumes:
+          - /home/github/.cache/cache-http/assets:/app/assets
+        # Only map ports for direct-on-host case. Not needed for Dockerized builds!
+        ports:
+           - 127.0.0.1:3000:80
+
+
     steps:
     - name: Setup Node.js ${{ matrix.node-versions }}
       uses: actions/setup-node@v1
@@ -36,14 +68,26 @@ jobs:
     #   run: yarn install
 
     - name: Yarn Install (with cache)
-      uses: kevincobain2000/action-cache-http@v2
+      uses: kevincobain2000/action-cache-http@v3
       with:
         version: ${{ matrix.node-versions }}
         lock_file: yarn.lock
         install_command: yarn install
+        operating_dir: ./
         destination_folder: node_modules
-        cache_http_api: "https://yourdomain.com/path/to/installation/cache-http"
+        # For Dockerized builds, this should match the service name.
+        # cache_http_api: "http://cache-http"
+        # For direct-on-host builds, use the custom port you mapped above
+        cache_http_api: "http://127.0.0.1:3000"
         http_proxy: ""
+```
+
+If for some reason you want to use the Dockerized version of this service, below are details
+on how to run it yourself. Also see the example `.sh` scripts distributed with the project.
+
+#### Run
+```
+go run main.go 3000
 ```
 
 #### Deploy


### PR DESCRIPTION
This PR makes the project to easier to install, use and manage.

Ideally, along with merging this a public Docker image for the project would be published to
Github's container registry, which is a free service for public images.

Here are the improvements:

 * There's no longer an additional service to manually install or manage. Instead, the the caching service runs as a service container. Because the Docker service on your host will cache the service image, it takes mere seconds to start up.
 * Instead of writing the cache back into the docker image, the best practice of using a data volume is volumed. Here we use a bind mount to store the cache on the host.  This makes it easy to script pruning the cache and demonstrates how the cache can located anywhere on the host.
 * Installation is now simpler by not defaulting to having authentication set up, instead relying on restricting requests from localhost or the private network for security.
 * Documentation examples are provided that should work for both the direct-on-host case and the dockerized-build case.

Some details to highlight:

 - In the README I bumped the version to "3", assuming there would be a major version bump if this is merged.
 - In the YAML I also added `operating_dir: ./` because it was required in my case to work.  This seems like a bug that this was required for a default case, but it doesn't hurt and shows off that the option exists.
-  I put in a fake path to the public Docker image for the project that I recommend is published.
